### PR TITLE
Ensure useSelector returns correct value type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,12 +86,16 @@ export function Provider<S>({
 }
 
 // It requires a selector and returns a derived store value.
-export function useSelector<S, V>(selector: (s: S) => V) {
+export function useSelector<S, V>(selector: (s: S) => V): V {
   const mutableSource = React.useContext(MutableSourceContext);
   // Pass the store state to user selector:
   const getSnapshot = React.useCallback(store => selector(store.get()), [
     selector,
   ]);
 
-  return (React as any).unstable_useMutableSource(mutableSource, getSnapshot, subscribe);
+  return (React as any).unstable_useMutableSource(
+    mutableSource,
+    getSnapshot,
+    subscribe
+  );
 }


### PR DESCRIPTION
`useSelector` was returning the `any` type instead of the expected `V`. 

tsdx lint failed on line 96. I ran `yarn lint fix` on it and that's why that range is updated. 