### PR TITLE
Migrate to useSyncExternalStore, make typesafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img width="243" alt="Mutik" src="https://user-images.githubusercontent.com/4060187/76576100-81dff980-6497-11ea-93fd-52fc765b9fdc.png">
 
-> A tiny (495B) immutable state management library based on Immer
+> A tiny (696B) immutable state management library based on Immer
 
 ## Quick Start
 
@@ -19,10 +19,9 @@ or
 
 - [Example](#example)
 - [API](#api)
-  - [`createStore<S>(intialState: S): Store<S>`](#createstoresintialstate-s-stores)
+  - [`createStore<State>(intialState: State): [Store<State>, useStore<Value>(selector: (state: State) => Value): Value]`](#createstorestateintialstate-state-storestate-usestorevalueselector-state-state--value-value)
     - [`store`](#store)
-  - [`useSelector<S, V>(selector: (s: S) => V)`](#useselectors-vselector-s-s--v)
-  - [`<Provider />`](#provider-)
+    - [`useStore<Value>(selector: (state: State) => Value): Value`](#usestorevalueselector-state-state--value-value)
 - [Author](#author)
 - [Inspiration](#inspiration)
 
@@ -30,31 +29,23 @@ or
 
 ## Example
 
-To use Mutik with React, you'll need to install React and React DOM from the experimental release channel because Mutik uses the recently-merged `useMutableSource` hook internally.
-
-```bash
-yarn add react@experimental react-dom@experimental
-```
-
 ```jsx
 import React from 'react';
 import { render } from 'react-dom';
 import { createStore, Provider, useSelector } from 'mutik';
 
 // Create a lil' store with some state
-let store = createStore({
+let [store, useStore] = createStore({
   count: 0,
 });
 
-// Pass the store to the Provider.
+// The app doesn't need a provider
 function App() {
   return (
-    <Provider store={store}>
-      <div>
-        <Label />
-        <Buttons />
-      </div>
-    </Provider>
+    <div>
+      <Label />
+      <Buttons />
+    </div>
   );
 }
 
@@ -84,11 +75,11 @@ function Buttons() {
   );
 }
 
-// Lastly, you can subcribe to "slices" of state with useSelector
-// Note: be sure to memoize these with React.useCallback if you need to select based on props
+// Lastly, you can subcribe to "slices" of state by passing a selector to use
+// state. The component will only be re-rendered when that portion of state
+// re-renders.
 function Label() {
-  const selector = React.useCallback(state => state.count, []);
-  const count = useSelector(selector);
+  const count = useStore(state => state.count);
   return <p>The count is {count}</p>;
 }
 
@@ -97,7 +88,7 @@ render(<App />, window.root);
 
 ## API
 
-### `createStore<S>(intialState: S): Store<S>`
+### `createStore<State>(intialState: State): [Store<State>, useStore<Value>(selector: (state: State) => Value): Value]`
 
 Create a Mutik `store` given some initial state. The `store` has the following API you can use in or out of React.
 
@@ -112,9 +103,9 @@ Create a Mutik `store` given some initial state. The `store` has the following A
 | `reset(): void`                                       | Set state back to the `initialState` used when creating the store                                                                               |
 | `mutate(updater: (draft: Draft) => void \| S): void;` | Immer-style updater function.                                                                                                                   |
 
-### `useSelector<S, V>(selector: (s: S) => V)`
+#### `useStore<Value>(selector: (state: State) => Value): Value`
 
-React hook to subscribe to Mutik state. Must be called underneath a Mutik `Provider`.
+React hook to subscribe to Mutik state.
 
 ```jsx
 const selector = state => state.count;
@@ -125,36 +116,12 @@ function Label() {
 }
 ```
 
-You can use props with Mutik selector. For performance, it's a good idea to memoize the selector with `React.useCallback`. For example:
+You can use props with Mutik selector.
 
 ```jsx
 function User({ id }) {
-  const selector = React.useCallback(state => state.users[id], [id]);
-  const user = useSelector(selector);
+  const user = useSelector(state => state.users[id]);
   return <p>The username is {user.name}</p>;
-}
-```
-
-### `<Provider />`
-
-Mutik context provider. Pass your store as `store` prop. For example:
-
-```jsx
-import React from 'react';
-import { createStore, Provider } from 'mutik';
-
-// Create a lil' store with some state
-let store = createStore({
-  count: 0,
-});
-
-// Pass the store to the Provider.
-function App() {
-  return (
-    <Provider store={store}>
-      <div>{/* ... stuff */}</div>
-    </Provider>
-  );
 }
 ```
 

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,33 +1,30 @@
 import 'react-app-polyfill/ie11';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Provider, createStore, useSelector, Store } from '../.';
+import { createStore, Store } from '../.';
 
 export interface State {
   count: number;
 }
 
-export const store = createStore<State>({
+export const [store, useStore] = createStore<State>({
   count: 0,
 });
 
 const App = () => {
   return (
-    <Provider store={store}>
-      <div>
-        <Label />
-        <Buttons store={store} />
-        <ResetButton />
-      </div>
-    </Provider>
+    <div>
+      <Label />
+      <Buttons store={store} />
+      <ResetButton />
+    </div>
   );
 };
 
 function Label() {
   // Since our Mutik state is just the  { count } itself,
   // our selector is very simple!
-  const selector = React.useCallback(state => state.count, []);
-  const count = useSelector(selector);
+  const count = useStore(state => state.count);
   return <p>The count is {count}</p>;
 }
 
@@ -44,6 +41,7 @@ function Buttons({ store }: { store: Store<State> }) {
       state.count--;
     });
   }
+
   return (
     <>
       <button onClick={decrement}>Decrement</button>

--- a/package.json
+++ b/package.json
@@ -35,13 +35,14 @@
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
     "husky": "^4.2.3",
-    "react": "^0.0.0-experimental-8b155d261",
-    "react-dom": "^0.0.0-experimental-8b155d261",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
     "tsdx": "^0.14.1",
     "typescript": "^3.8.3"
   },
   "dependencies": {
     "immer": "^6.0.1",
-    "tslib": "^1.11.1"
+    "tslib": "^1.11.1",
+    "use-sync-external-store": "^0.0.0-experimental-8f96c6b2a-20210909"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,31 +1,31 @@
-import * as React from 'react';
 import immer, { Draft } from 'immer';
+import { useSyncExternalStoreExtra as useSyncExternalStore } from 'use-sync-external-store/extra';
 
 type Listener = Function;
 
-type UpdaterFn<S> = (prevState: S) => S;
+type UpdaterFn<State> = (prevState: State) => State;
 
-export interface Store<S> {
-  get(): S;
-  set(nextState: S): void;
-  set(updater: UpdaterFn<S>): void;
-  on(listener: Function): () => void;
-  off(listener: Function): void;
+export interface Store<State> {
+  get(): State;
+  set(nextState: State): void;
+  set(updater: UpdaterFn<State>): void;
+  on(listener: Listener): () => void;
+  off(listener: Listener): void;
   reset(): void;
-  mutate(updater: (draft: Draft<S>) => void | S): void;
+  mutate(updater: (draft: Draft<State>) => void | State): void;
 }
 
-export function createStore<S>(initialState: S): Store<S> {
+export function createStore<State>(initialState: State) {
   let listeners: Listener[] = [];
   let currentState = initialState;
-  return {
+  const store = {
     get() {
       return currentState;
     },
-    set(nextState: S | UpdaterFn<S>) {
+    set(nextState: State | UpdaterFn<State>) {
       currentState =
         typeof nextState === 'function'
-          ? (nextState as UpdaterFn<S>)(currentState)
+          ? (nextState as UpdaterFn<State>)(currentState)
           : nextState;
       listeners.forEach(listener => listener());
     },
@@ -39,59 +39,20 @@ export function createStore<S>(initialState: S): Store<S> {
     reset() {
       this.set(initialState);
     },
-    mutate(updater: (draft: Draft<S>) => void | S) {
+    mutate(updater: (draft: Draft<State>) => void | State) {
       let currState = this.get();
       let nextState = immer(currState, updater);
-      if (nextState !== currState) this.set(nextState as S);
+      if (nextState !== currState) this.set(nextState as State);
     },
   };
-}
 
-// Because the state is immutable,
-// it can be used as the "version".
-function getStoreVersion<S>(store: Store<S>) {
-  return store.get();
-}
+  function useStore<DerivedValue>(
+    selector: (state: State) => DerivedValue = state =>
+      (state as unknown) as DerivedValue
+  ) {
+    const selection = useSyncExternalStore(store.on, store.get, selector);
+    return selection;
+  }
 
-// Subscribe is simple in the case of Mutik.
-// Since it does not require any seletor-specific logic,
-// it can be declared in module scope.
-function subscribe<S>(store: Store<S>, callback: Listener) {
-  return store.on(callback);
-}
-
-const MutableSourceContext = React.createContext<Store<unknown>>(null as any);
-
-// This mimics the current Redux <Provider> API.
-// It shares the store (really now a MutableSource wrapper)
-// with components below in the tree that read from the store.
-export function Provider<S>({
-  children,
-  store,
-}: {
-  children: React.ReactNode;
-  store: Store<S>;
-}) {
-  const mutableSource = React.useMemo(() => {
-    // Wrap the Mutik store in a MutableSource object.
-    // The useMutableSource() hook works with this type of object.
-    return (React as any).unstable_createMutableSource(store, getStoreVersion);
-  }, [store]);
-
-  return React.createElement(
-    MutableSourceContext.Provider,
-    { value: mutableSource },
-    children
-  );
-}
-
-// It requires a selector and returns a derived store value.
-export function useSelector<S, V>(selector: (s: S) => V) {
-  const mutableSource = React.useContext(MutableSourceContext);
-  // Pass the store state to user selector:
-  const getSnapshot = React.useCallback(store => selector(store.get()), [
-    selector,
-  ]);
-
-  return (React as any).unstable_useMutableSource(mutableSource, getSnapshot, subscribe);
+  return [store, useStore] as const;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,15 @@
+declare module 'use-sync-external-store' {
+  export function useSyncExternalStore<Snapshot>(
+    subscribe: (callback: Function) => () => void,
+    getSnapshot: () => Snapshot
+  ): Snapshot;
+}
+
+declare module 'use-sync-external-store/extra' {
+  export function useSyncExternalStoreExtra<Snapshot, Selection>(
+    subscribe: (callback: Function) => () => void,
+    getSnapshot: () => Snapshot,
+    selector: (snapshot: Snapshot) => Selection,
+    isEqual?: (a: Selection, b: Selection) => boolean
+  ): Selection;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4799,30 +4799,29 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-react-dom@^0.0.0-experimental-8b155d261:
-  version "0.0.0-fec00a869"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-fec00a869.tgz#f952e11a31e446c00e87603998d7780bc51bdbd9"
-  integrity sha512-atB5i2HgCvbvhtGXq9oaX/BCL2AFZjnccougU8S9eulRFNQbNrfGNwIcj04PRo3XU1ZsBw5syL/5l596UaolKA==
+react-dom@^16.14.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
+  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "0.0.0-fec00a869"
+    scheduler "^0.19.1"
 
 react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react@^0.0.0-experimental-8b155d261:
-  version "0.0.0-fec00a869"
-  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-fec00a869.tgz#1803f4f17cdd5adfdf614de2386c5fb5c84bbe91"
-  integrity sha512-FaS3ViFU4ag7cuhDHQgGK3DAdWaD8YFXzEbO/Qzz33Si7VEzRRdnyoegFwg7VkEKxR6CvCVP6revi9Tm3Gq+WQ==
+react@^16.14.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "0.0.0-fec00a869"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -5204,10 +5203,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scheduler@0.0.0-fec00a869:
-  version "0.0.0-fec00a869"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-fec00a869.tgz#e28ff1aa107e1d04d6e8901641b4fb1e3ba98577"
-  integrity sha512-0U25jnyBP6dRPYwaVW4WMYB0jJSYlrIHFmIuXv27X+KIHJr7vyE9gcFTqZ61NQTuxYLYepAHnUs4KgQEUDlI+g==
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -5995,6 +5994,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+use-sync-external-store@^0.0.0-experimental-8f96c6b2a-20210909:
+  version "0.0.0-experimental-8f96c6b2a-20210909"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-0.0.0-experimental-8f96c6b2a-20210909.tgz#772c1b0b704766ac16eb1ce51d563f1d02f091c4"
+  integrity sha512-OlZbEQ2CKTKHEoKRQyJWcdsKqZQ7W+Sa29XEcTqNpp+P7D6STE9XbCHVLEPp6CXuQeXg8NTAI0o1v7p22vtIZQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Fixes #25 

Okay, so... this turned into a whole thing. It's a breaking change but worth it in my opinion.

As I mentioned in #25, there's a new API called `useSyncExternalStore` which replaces `useMutableSource` with a few benefits. One benefit is the whole source part goes away. This is particularly interesting for mutik, because it means we can essentially do away with the Provider wholesale. To get the typing right and to ensure `useSelector` (now `useStore`, more on that in a second) has access to the store I've turned `createStore` into a function that returns both the store and the hook to access it. 

Usage is something like this:

```
const [store, useStore] = createStore({ count: 0 });
```

One of the new things with the `useSyncExternalStore` is that selectors aren't required to be memoized. From my understanding, with `useMutableSource` essentially you'd resubscribe to the store every time the selector changed. `useSyncExternalStore` on the other hand has dedicated support for selectors... hell, it even memoizes `getSnapshot` for us! The net result is a far simpler/smaller implementation.

The last bit of cool news: `useSyncExternalStore` is going to be released in React v18 but it _also_ is being published in `use-sync-external-store` and will be backwards compatible with all hooks versions. I set the React version to the latest v16. No more experimental react installs! 